### PR TITLE
feat: add portfolio risk tracking

### DIFF
--- a/src/components/GameArea.tsx
+++ b/src/components/GameArea.tsx
@@ -8,6 +8,8 @@ interface GameAreaProps {
   artifactsData: any[];
   weights: { [key: string]: number };
   returns: number | null;
+  volatility: number | null;
+  drawdown: number | null;
   onWeightChange: (key: string, value: number) => void;
   onNextDay: () => void;
   onResetGame: () => void;
@@ -223,6 +225,8 @@ export const GameArea: React.FC<GameAreaProps> = ({
   artifactsData,
   weights,
   returns,
+  volatility,
+  drawdown,
   onWeightChange,
   onNextDay,
   onResetGame,
@@ -355,6 +359,16 @@ export const GameArea: React.FC<GameAreaProps> = ({
           <ReturnsValue>
             {returns !== null ? `${returns}%` : '请点击"下一天"模拟收益'}
           </ReturnsValue>
+          {volatility !== null && (
+            <div>
+              波动率: {volatility}%{volatility > 20 ? ' ⚠️ 波动较高' : ''}
+            </div>
+          )}
+          {drawdown !== null && (
+            <div>
+              回撤: {drawdown}%{drawdown < -20 ? ' ⚠️ 回撤严重' : ''}
+            </div>
+          )}
         </ReturnsInfo>
         
         <ActionButtons>

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -14,7 +14,7 @@ export const GameLayout: React.FC = () => {
     // State
     companyName, avatar, theme, coins, gems, wheelOpen, wheelResult, wheelUsed,
     aiChatOpen, aiInput, aiResponse, dilemma, quiz, quizAnswered, endgame,
-    showSummary, history, weights, day, returns, event, task, badges,
+    showSummary, history, weights, day, returns, volatility, drawdown, event, task, badges,
     showModal, modalContent, pendingCompanyName, avatarOptions,
     allowedAssets, pendingCoinRequest, aiPersonality, aiEnabled,
 
@@ -72,6 +72,7 @@ export const GameLayout: React.FC = () => {
         
         <GameArea
           task={task} event={event} artifactsData={artifactsData} weights={weights} returns={returns}
+          volatility={volatility} drawdown={drawdown}
           onWeightChange={handleWeightChange} onNextDay={nextDay} onResetGame={resetGame}
           onShowModal={(content) => { setShowModal(true); setModalContent(content); }}
         />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,13 +82,15 @@ export interface AIPartner {
 
 // Game State Types
 export interface GameState {
-	day: number;
-	weights: { [key: string]: number };
-	returns: number | null;
-	coins: number;
-	gems: number;
-	badges: string[];
-	history: GameHistory[];
+        day: number;
+        weights: { [key: string]: number };
+        returns: number | null;
+        volatility: number | null;
+        drawdown: number | null;
+        coins: number;
+        gems: number;
+        badges: string[];
+        history: GameHistory[];
 }
 
 export interface GameHistory {


### PR DESCRIPTION
## Summary
- calculate daily returns with asset correlations, portfolio volatility, and drawdown
- drive game state from calculateDailyReturns and surface volatility/drawdown
- display risk warnings for high volatility or drawdown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad3c00d9dc8324a27a57b81cfdb582