### PR TITLE
feat: track stars and progress

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -12,7 +12,7 @@ export const GameLayout: React.FC = () => {
   
   const {
     // State
-    companyName, avatar, theme, coins, gems, wheelOpen, wheelResult, wheelUsed,
+    companyName, avatar, theme, coins, gems, stars, wheelOpen, wheelResult, wheelUsed,
     aiChatOpen, aiInput, aiResponse, dilemma, quiz, quizAnswered, endgame,
     showSummary, history, weights, day, returns, event, task, badges,
     showModal, modalContent, pendingCompanyName, avatarOptions,
@@ -54,7 +54,7 @@ export const GameLayout: React.FC = () => {
   return (
     <div className="legacy-container" style={{ paddingTop: 0, maxWidth: '1200px', margin: '2rem auto' }}>
       <TopBar
-        {...{ companyName, avatar, badges, day, coins, gems, theme }}
+        {...{ companyName, avatar, day, coins, gems, stars, theme }}
         onEditCompany={handlers.editCompany}
         onRequestCoins={handlers.requestCoins}
       />
@@ -68,7 +68,7 @@ export const GameLayout: React.FC = () => {
       />
 
       <div style={{ display: 'flex', gap: '2rem', flexWrap: 'nowrap', marginBottom: '2rem' }}>
-        <Sidebar {...{ aiPartnerData, badgesData, badges, history }} onBadgeClick={handlers.badgeClick} />
+        <Sidebar {...{ aiPartnerData, badgesData, badges, history, stars }} onBadgeClick={handlers.badgeClick} />
         
         <GameArea
           task={task} event={event} artifactsData={artifactsData} weights={weights} returns={returns}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ interface SidebarProps {
   badgesData: any[];
   badges: string[];
   history: any[];
+  stars: number;
   onBadgeClick: (badge: any) => void;
 }
 
@@ -78,6 +79,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   badgesData,
   badges,
   history,
+  stars,
   onBadgeClick
 }) => {
   return (
@@ -101,6 +103,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
             return aiPartnerData.feedbackTemplates[0].replace('{asset}', '资产').replace('{percent}', '分散');
           })()}
         </AiPartnerDescription>
+      </Section>
+
+      {/* Stars Section */}
+      <Section>
+        <SectionTitle $color={theme.colors.meme.accent}>守护之星</SectionTitle>
+        <div style={{ color: theme.colors.cyber.text, fontWeight: 700 }}>⭐ {stars}</div>
       </Section>
 
       {/* Badges Section */}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,10 +5,10 @@ import { theme } from '../styles/theme';
 interface TopBarProps {
   companyName: string;
   avatar: string;
-  badges: string[];
   day: number;
   coins: number;
   gems: number;
+  stars: number;
   theme: string;
   onEditCompany: () => void;
   onRequestCoins: () => void;
@@ -127,10 +127,10 @@ const RequestButton = styled.button`
 export const TopBar: React.FC<TopBarProps> = ({
   companyName,
   avatar,
-  badges,
   day,
   coins,
   gems,
+  stars,
   theme: currentTheme,
   onEditCompany,
   onRequestCoins
@@ -152,7 +152,7 @@ export const TopBar: React.FC<TopBarProps> = ({
         </CompanyInfo>
         
         <StatusInfo>
-          守护者之星：{badges.length}/5
+          星星：{stars}
         </StatusInfo>
         
         <StatusInfoSecondary>

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -18,6 +18,8 @@ export const useGameState = () => {
   // Resource Management
   const [coins, setCoins] = useState(100);
   const [gems, setGems] = useState(5);
+  const [stars, setStars] = useState(0);
+  const [progress, setProgress] = useState(0);
   const [allowedAssets, setAllowedAssets] = useState<string[]>(['tech','bond','gold','crypto','esg','stablecoin','yield']);
   const [pendingCoinRequest, setPendingCoinRequest] = useState<number | null>(null);
 
@@ -89,6 +91,15 @@ export const useGameState = () => {
     );
   }, []);
 
+  const addStars = useCallback((count: number = 1) => {
+    setStars(prev => {
+      const newStars = prev + count;
+      const newProgress = Math.min(100, Math.floor(newStars / 5) * 25);
+      setProgress(newProgress);
+      return newStars;
+    });
+  }, []);
+
 
   // Handle spin wheel
   const handleSpinWheel = useCallback(() => {
@@ -124,6 +135,8 @@ export const useGameState = () => {
     setQuizResult('');
     setCoins(100);
     setGems(5);
+    setStars(0);
+    setProgress(0);
     setEndgame(false);
     setShowSummary(false);
   }, []);
@@ -204,6 +217,8 @@ export const useGameState = () => {
     setCoins(c => c + Math.max(0, Math.floor(dayReturn / 10)));
     if (dayReturn > 50) setGems(g => g + 1);
 
+    if (dayReturn > 0) addStars(1);
+
     // Badge logic
     let newBadges = [...badges];
     if (Object.values(weights).filter((w) => (w as number) > 0).length >= 4 && !badges.includes('分散者')) {
@@ -240,6 +255,8 @@ export const useGameState = () => {
     theme,
     coins,
     gems,
+    stars,
+    progress,
     wheelOpen,
     wheelResult,
     wheelUsed,
@@ -278,6 +295,8 @@ export const useGameState = () => {
     setTheme,
     setCoins,
     setGems,
+    setStars,
+    setProgress,
     setWheelOpen,
     setWheelResult,
     setWheelUsed,
@@ -313,6 +332,7 @@ export const useGameState = () => {
     requestCoins,
     approveCoinRequest,
     rejectCoinRequest,
-    toggleAllowedAsset
+    toggleAllowedAsset,
+    addStars
   };
 };


### PR DESCRIPTION
## Summary
- track stars and progress in game state
- add milestone logic awarding progress on successful days
- show star count in top bar and sidebar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3d0c97a88324990250d8926a20d0