### PR TITLE
feat: add ai feedback rules and tips

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -13,7 +13,7 @@ export const GameLayout: React.FC = () => {
   const {
     // State
     companyName, avatar, theme, coins, gems, stars, wheelOpen, wheelResult, wheelUsed,
-    aiChatOpen, aiInput, aiResponse, dilemma, quiz, quizAnswered, endgame,
+    aiChatOpen, aiInput, aiResponse, aiMessages, dilemma, quiz, quizAnswered, endgame,
     showSummary, history, weights, day, returns, volatility, drawdown, event, task, badges,
     showModal, modalContent, pendingCompanyName, avatarOptions,
     allowedAssets, pendingCoinRequest, aiPersonality, aiEnabled,
@@ -99,7 +99,7 @@ export const GameLayout: React.FC = () => {
         dilemma={dilemma} quiz={quiz} quizAnswered={quizAnswered} endgame={endgame} showSummary={showSummary}
         companyName={companyName} avatar={avatar} avatarOptions={avatarOptions} theme={theme}
         pendingCompanyName={pendingCompanyName} aiPartnerData={aiPartnerData} aiInput={aiInput}
-        aiResponse={aiResponse} returns={returns} badges={badges}
+        aiResponse={aiResponse} aiMessages={aiMessages} returns={returns} badges={badges}
         onModalClose={handlers.modalClose} onCompanyNameChange={setCompanyName} onAvatarChange={setAvatar}
         onThemeChange={setTheme} onPendingCompanyNameChange={setPendingCompanyName}
         onDilemmaClose={handlers.dilemmaClose} onQuizAnswer={handlers.quizAnswer}

--- a/src/components/Modals.tsx
+++ b/src/components/Modals.tsx
@@ -20,6 +20,7 @@ interface ModalsProps {
   aiPartnerData: AIPartner;
   aiInput: string;
   aiResponse: string;
+  aiMessages: string[];
   returns: number | null;
   badges: string[];
   onModalClose: () => void;
@@ -331,6 +332,7 @@ export const Modals: React.FC<ModalsProps> = ({
   aiPartnerData,
   aiInput,
   aiResponse,
+  aiMessages,
   returns,
   badges,
   onModalClose,
@@ -444,11 +446,14 @@ export const Modals: React.FC<ModalsProps> = ({
             <AiDescription>
               你可以向AI伙伴提问任何金融相关问题。
             </AiDescription>
-            <AiInput 
-              type="text" 
-              value={aiInput} 
-              onChange={e => onAiInputChange(e.target.value)} 
-              placeholder="请输入你的问题..." 
+            {aiMessages.map((msg, idx) => (
+              <AiResponse key={idx}>{msg}</AiResponse>
+            ))}
+            <AiInput
+              type="text"
+              value={aiInput}
+              onChange={e => onAiInputChange(e.target.value)}
+              placeholder="请输入你的问题..."
             />
             <ModalButton $variant="primary" onClick={onAiAsk}>
               发送

--- a/src/constants/ai-feedback.json
+++ b/src/constants/ai-feedback.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "negative_returns",
+    "type": "returnsBelow",
+    "threshold": 0,
+    "template": "今天的收益为{returns}%，别灰心，试着调整你的策略。"
+  },
+  {
+    "id": "crypto_overweight",
+    "type": "weightAbove",
+    "asset": "crypto",
+    "threshold": 50,
+    "template": "你在{asset}上的配置达到{percent}%，可能有些集中，记得分散风险。"
+  },
+  {
+    "id": "badge_earned",
+    "type": "badgeEarned",
+    "template": "恭喜获得{badge}徽章，继续保持！"
+  }
+]


### PR DESCRIPTION
## Summary
- add rule-based AI feedback configuration
- queue and display AI tips based on daily game state

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad42a2073c8324920c624c6344d419