### PR TITLE
feat: add interactive dilemma decisions

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -25,7 +25,7 @@ export const GameLayout: React.FC = () => {
 
     // Functions
     handleSpinWheel, handleAiAsk, resetGame, handleWeightChange, nextDay,
-    requestCoins, approveCoinRequest, rejectCoinRequest, toggleAllowedAsset
+    requestCoins, approveCoinRequest, rejectCoinRequest, toggleAllowedAsset, handleDilemmaAnswer
   } = gameState;
 
   const aiPartnerData = aiPersonalities.find(p => p.id === aiPersonality) || aiPersonalities[0];
@@ -102,7 +102,7 @@ export const GameLayout: React.FC = () => {
         aiResponse={aiResponse} returns={returns} badges={badges}
         onModalClose={handlers.modalClose} onCompanyNameChange={setCompanyName} onAvatarChange={setAvatar}
         onThemeChange={setTheme} onPendingCompanyNameChange={setPendingCompanyName}
-        onDilemmaClose={handlers.dilemmaClose} onQuizAnswer={handlers.quizAnswer}
+        onDilemmaClose={handlers.dilemmaClose} onDilemmaAnswer={handleDilemmaAnswer} onQuizAnswer={handlers.quizAnswer}
         onQuizClose={() => setQuiz(null)} onEndgameClose={handlers.endgameClose}
         onSummaryClose={handlers.summaryClose} onAiInputChange={setAiInput}
         onAiAsk={handleAiAsk} onAiChatClose={handlers.aiChatClose} onResetGame={resetGame}

--- a/src/components/Modals.tsx
+++ b/src/components/Modals.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { theme } from '../styles/theme';
-import type { AIPartner } from '../types';
+import type { AIPartner, Dilemma } from '../types';
 
 interface ModalsProps {
   showModal: boolean;
   modalContent: string;
   aiChatOpen: boolean;
-  dilemma: string | null;
+  dilemma: Dilemma | null;
   quiz: any;
   quizAnswered: string | null;
   endgame: boolean;
@@ -28,6 +28,7 @@ interface ModalsProps {
   onThemeChange: (theme: string) => void;
   onPendingCompanyNameChange: (name: string) => void;
   onDilemmaClose: () => void;
+  onDilemmaAnswer: (optionIndex: number) => string;
   onQuizAnswer: (answer: string) => void;
   onQuizClose: () => void;
   onEndgameClose: () => void;
@@ -339,6 +340,7 @@ export const Modals: React.FC<ModalsProps> = ({
   onThemeChange,
   onPendingCompanyNameChange,
   onDilemmaClose,
+  onDilemmaAnswer,
   onQuizAnswer,
   onQuizClose,
   onEndgameClose,
@@ -348,10 +350,11 @@ export const Modals: React.FC<ModalsProps> = ({
   onAiChatClose,
   onResetGame
 }) => {
-  // Helper to extract options from dilemma question
-  const getDilemmaOptions = (q: string) => {
-    return ['A. 坚持长期持有', 'B. 立即止损', 'C. 增加投资'];
-  };
+  const [dilemmaResult, setDilemmaResult] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDilemmaResult(null);
+  }, [dilemma]);
 
   return (
     <>
@@ -467,18 +470,30 @@ export const Modals: React.FC<ModalsProps> = ({
         <ModalOverlay>
           <ModalContent $variant="dilemma">
             <ModalTitle $color={theme.colors.cyber.secondary}>决策时刻</ModalTitle>
-            <DilemmaText>{dilemma}</DilemmaText>
-            <DilemmaOptions>
-              {getDilemmaOptions(dilemma).map((opt, idx) => (
-                <ModalButton 
-                  $variant="primary" 
-                  key={opt+idx} 
-                  onClick={onDilemmaClose}
-                >
-                  {opt}
+            <DilemmaText>{dilemma.text}</DilemmaText>
+            {dilemmaResult ? (
+              <>
+                <DilemmaText>{dilemmaResult}</DilemmaText>
+                <ModalButton $variant="primary" onClick={onDilemmaClose}>
+                  继续
                 </ModalButton>
-              ))}
-            </DilemmaOptions>
+              </>
+            ) : (
+              <DilemmaOptions>
+                {dilemma.options.map((opt, idx) => (
+                  <ModalButton
+                    $variant="primary"
+                    key={idx}
+                    onClick={() => {
+                      const res = onDilemmaAnswer(idx);
+                      setDilemmaResult(res);
+                    }}
+                  >
+                    {opt.text}
+                  </ModalButton>
+                ))}
+              </DilemmaOptions>
+            )}
           </ModalContent>
         </ModalOverlay>
       )}

--- a/src/modules/dilemmas.ts
+++ b/src/modules/dilemmas.ts
@@ -2,9 +2,104 @@ import { Dilemma } from '../types';
 
 // Dilemma questions presented during gameplay
 export const dilemmas: Dilemma[] = [
-  { text: '市场波动加剧，你会选择？' },
-  { text: '突发利空消息，你会选择？' },
-  { text: '资产暴涨，你会选择？' },
-  { text: '行业政策变化，你会选择？' },
-  { text: '朋友推荐新资产，你会选择？' },
+  {
+    text: '市场波动加剧，你会选择？',
+    options: [
+      {
+        text: '坚持长期持有',
+        consequence: '你顶住波动，学习到长期主义。',
+        skill: 'risk-management'
+      },
+      {
+        text: '立即止损',
+        consequence: '你及时止损，保住了本金。',
+        skill: 'risk-management'
+      },
+      {
+        text: '逢低加仓',
+        consequence: '你在低位加仓，承担更高风险也可能获得回报。',
+        skill: 'diversification'
+      }
+    ]
+  },
+  {
+    text: '突发利空消息，你会选择？',
+    options: [
+      {
+        text: '评估后再行动',
+        consequence: '你进行了冷静分析，提升了风险管理能力。',
+        skill: 'risk-management'
+      },
+      {
+        text: '立刻抛售',
+        consequence: '你迅速卖出，避免了更大损失但也可能错过反弹。',
+        skill: 'knowledge'
+      },
+      {
+        text: '忽略消息',
+        consequence: '你忽视了消息，市场继续下跌造成损失。',
+        skill: 'knowledge'
+      }
+    ]
+  },
+  {
+    text: '资产暴涨，你会选择？',
+    options: [
+      {
+        text: '立即卖出获利',
+        consequence: '你锁定利润，见好就收。',
+        skill: 'risk-management'
+      },
+      {
+        text: '继续持有',
+        consequence: '你期待更高收益，但风险也随之增加。',
+        skill: 'knowledge'
+      },
+      {
+        text: '加码买入',
+        consequence: '你加大投入，若回调可能遭受损失。',
+        skill: 'risk-management'
+      }
+    ]
+  },
+  {
+    text: '行业政策变化，你会选择？',
+    options: [
+      {
+        text: '调整资产配置',
+        consequence: '你灵活调整，成功分散了风险。',
+        skill: 'diversification'
+      },
+      {
+        text: '保持原策略',
+        consequence: '你坚持原有策略，可能错过新机会。',
+        skill: 'knowledge'
+      },
+      {
+        text: '深入研究再决策',
+        consequence: '你通过学习提升了知识水平。',
+        skill: 'knowledge'
+      }
+    ]
+  },
+  {
+    text: '朋友推荐新资产，你会选择？',
+    options: [
+      {
+        text: '自行研究后决定',
+        consequence: '你通过研究提高了知识水平。',
+        skill: 'knowledge'
+      },
+      {
+        text: '跟风立即购买',
+        consequence: '盲目跟风，风险增加。',
+        skill: 'risk-management'
+      },
+      {
+        text: '礼貌拒绝',
+        consequence: '你保持稳健策略，增强风险管理。',
+        skill: 'risk-management'
+      }
+    ]
+  }
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,9 +55,16 @@ export interface Badge {
 }
 
 // Dilemma Types
+export interface DilemmaOption {
+        text: string;
+        consequence: string;
+        skill: 'diversification' | 'risk-management' | 'knowledge';
+}
+
 export interface Dilemma {
         text: string;
         icon?: string;
+        options: DilemmaOption[];
 }
 
 // Spin Wheel Types


### PR DESCRIPTION
## Summary
- enrich dilemma data with selectable options, consequences, and skill tags
- add decision modal to present dilemmas and show outcomes
- track completed dilemmas and skill improvements in game state

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad42a39e9083248979a153b4f10364