### PR TITLE
feat: add ai feedback rules and modal tips

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -13,7 +13,7 @@ export const GameLayout: React.FC = () => {
   const {
     // State
     companyName, avatar, theme, coins, gems, stars, wheelOpen, wheelResult, wheelUsed,
-    aiChatOpen, aiInput, aiResponse, dilemma, quiz, quizAnswered, endgame,
+    aiChatOpen, aiInput, aiResponse, aiMessages, dilemma, quiz, quizAnswered, endgame,
     showSummary, history, weights, day, returns, volatility, drawdown, event, task, badges,
     showModal, modalContent, pendingCompanyName, avatarOptions,
     allowedAssets, pendingCoinRequest, aiPersonality, aiEnabled,
@@ -99,7 +99,7 @@ export const GameLayout: React.FC = () => {
         dilemma={dilemma} quiz={quiz} quizAnswered={quizAnswered} endgame={endgame} showSummary={showSummary}
         companyName={companyName} avatar={avatar} avatarOptions={avatarOptions} theme={theme}
         pendingCompanyName={pendingCompanyName} aiPartnerData={aiPartnerData} aiInput={aiInput}
-        aiResponse={aiResponse} returns={returns} badges={badges}
+        aiResponse={aiResponse} aiMessages={aiMessages} returns={returns} badges={badges}
         onModalClose={handlers.modalClose} onCompanyNameChange={setCompanyName} onAvatarChange={setAvatar}
         onThemeChange={setTheme} onPendingCompanyNameChange={setPendingCompanyName}
         onDilemmaClose={handlers.dilemmaClose} onQuizAnswer={handlers.quizAnswer}

--- a/src/components/Modals.tsx
+++ b/src/components/Modals.tsx
@@ -20,6 +20,7 @@ interface ModalsProps {
   aiPartnerData: AIPartner;
   aiInput: string;
   aiResponse: string;
+  aiMessages: string[];
   returns: number | null;
   badges: string[];
   onModalClose: () => void;
@@ -331,6 +332,7 @@ export const Modals: React.FC<ModalsProps> = ({
   aiPartnerData,
   aiInput,
   aiResponse,
+  aiMessages,
   returns,
   badges,
   onModalClose,
@@ -444,11 +446,14 @@ export const Modals: React.FC<ModalsProps> = ({
             <AiDescription>
               你可以向AI伙伴提问任何金融相关问题。
             </AiDescription>
-            <AiInput 
-              type="text" 
-              value={aiInput} 
-              onChange={e => onAiInputChange(e.target.value)} 
-              placeholder="请输入你的问题..." 
+            {aiMessages.map((msg, idx) => (
+              <AiResponse key={idx}>{msg}</AiResponse>
+            ))}
+            <AiInput
+              type="text"
+              value={aiInput}
+              onChange={e => onAiInputChange(e.target.value)}
+              placeholder="请输入你的问题..."
             />
             <ModalButton $variant="primary" onClick={onAiAsk}>
               发送

--- a/src/constants/ai-feedback.json
+++ b/src/constants/ai-feedback.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "negative_returns",
+    "type": "returnsBelow",
+    "threshold": 0,
+    "template": "今天的收益为{returns}%，别灰心，试着调整你的策略。"
+  },
+  {
+    "id": "crypto_overweight",
+    "type": "weightAbove",
+    "asset": "crypto",
+    "threshold": 50,
+    "template": "你在{asset}上的配置达到{percent}%，可能有些集中，记得分散风险。"
+  },
+  {
+    "id": "badge_earned",
+    "type": "badgeEarned",
+    "template": "恭喜获得{badge}徽章，继续保持！"
+  }
+]

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -7,6 +7,7 @@ import { badges as badgeData } from '../modules/badges';
 import { dilemmas as dilemmaQuestions } from '../modules/dilemmas';
 import { handleSpinWheel as spinWheel } from '../modules/spinWheel';
 import aiPersonalities from '../constants/ai-personalities.json';
+import aiFeedbackRules from '../constants/ai-feedback.json';
 import { assets as assetsData } from '../modules/assets';
 import { getAiResponse } from '../utils/ai';
 import { calculateDailyReturns } from '../utils/game-logic';
@@ -36,6 +37,7 @@ export const useGameState = () => {
   const [aiResponse, setAiResponse] = useState('');
   const [aiPersonality, setAiPersonality] = useState<string>(aiPersonalities[0].id);
   const [aiEnabled, setAiEnabled] = useState(true);
+  const [aiMessages, setAiMessages] = useState<string[]>([]);
 
   // Dilemma/Quiz state
   const [dilemma, setDilemma] = useState<string | null>(null);
@@ -253,11 +255,44 @@ export const useGameState = () => {
     if ((weights.yield || 0) >= 20 && !badges.includes('收益智者')) {
       newBadges.push('收益智者');
     }
+    const earnedBadges = newBadges.filter(b => !badges.includes(b));
     setBadges(newBadges);
 
     // Track history
     setHistory([...history, { day: day + 1, weights: { ...weights }, event: ev, returns: dayReturn }]);
-  }, [day, returns, badges, weights, history, askedDilemmas, portfolioValue, peakValue]);
+
+    // AI feedback rules
+    if (aiEnabled) {
+      const personality = aiPersonalities.find(p => p.id === aiPersonality) || aiPersonalities[0];
+      const queue: string[] = [];
+      aiFeedbackRules.forEach(rule => {
+        if (rule.type === 'returnsBelow' && dayReturn < rule.threshold) {
+          const msg = rule.template.replace('{returns}', dayReturn.toFixed(2));
+          queue.push(msg);
+        }
+        if (rule.type === 'weightAbove') {
+          const w = (weights as any)[rule.asset] || 0;
+          if (w > rule.threshold) {
+            const msg = rule.template
+              .replace('{asset}', rule.asset)
+              .replace('{percent}', w.toFixed(0));
+            queue.push(msg);
+          }
+        }
+        if (rule.type === 'badgeEarned' && earnedBadges.length > 0) {
+          earnedBadges.forEach(b => {
+            const msg = rule.template.replace('{badge}', b);
+            queue.push(msg);
+          });
+        }
+      });
+      if (queue.length > 0) {
+        const styled = queue.map(m => `${personality.name}：${m}`);
+        setAiMessages(prev => [...prev, ...styled]);
+        setAiChatOpen(true);
+      }
+    }
+  }, [day, returns, badges, weights, history, askedDilemmas, portfolioValue, peakValue, aiEnabled, aiPersonality]);
 
   return {
     // State
@@ -274,6 +309,7 @@ export const useGameState = () => {
     aiChatOpen,
     aiInput,
     aiResponse,
+    aiMessages,
     dilemma,
     quiz,
     quizAnswered,


### PR DESCRIPTION
## Summary
- define AI feedback rules for negative returns, concentration, and badge celebrations
- queue personality-styled AI messages after each day in game state
- show queued AI tips in the AI chat modal
- display concentrations as whole-number percentages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad42a2073c8324920c624c6344d419