### PR TITLE
feat: track task objectives and rewards

### DIFF
--- a/src/components/GameArea.tsx
+++ b/src/components/GameArea.tsx
@@ -4,6 +4,8 @@ import { theme } from '../styles/theme';
 
 interface GameAreaProps {
   task: any;
+  taskObjective: string;
+  lastTaskResult: { title: string; completed: boolean; reward: { coins: number; gems: number; badge?: string } } | null;
   event: any;
   history: any[];
   artifactsData: any[];
@@ -234,6 +236,8 @@ const ActionButton = styled.button`
 
 export const GameArea: React.FC<GameAreaProps> = ({
   task,
+  taskObjective,
+  lastTaskResult,
   event,
   history,
   artifactsData,
@@ -264,6 +268,12 @@ export const GameArea: React.FC<GameAreaProps> = ({
           <TaskTitle>{task?.title || '暂无任务'}</TaskTitle>
           <TaskBackground>{task?.background || ''}</TaskBackground>
           <TaskTip>{task?.tip || ''}</TaskTip>
+          {taskObjective && <TaskTip>目标：{taskObjective}</TaskTip>}
+          {lastTaskResult && (
+            <TaskTip>
+              上个任务{lastTaskResult.completed ? `完成✅ 奖励：+${lastTaskResult.reward.coins}币 +${lastTaskResult.reward.gems}宝石${lastTaskResult.reward.badge ? ` +徽章：${lastTaskResult.reward.badge}` : ''}` : '未完成❌'}
+            </TaskTip>
+          )}
         </Card>
         
         <Card className="legacy-card">

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -14,7 +14,7 @@ export const GameLayout: React.FC = () => {
     // State
     companyName, avatar, theme, coins, gems, stars, wheelOpen, wheelResult, wheelUsed,
     aiChatOpen, aiInput, aiResponse, dilemma, quiz, quizAnswered, endgame,
-    showSummary, history, weights, day, returns, volatility, drawdown, event, task, badges,
+    showSummary, history, weights, day, returns, volatility, drawdown, event, task, taskObjective, lastTaskResult, badges,
     showModal, modalContent, pendingCompanyName, avatarOptions,
     allowedAssets, pendingCoinRequest, aiPersonality, aiEnabled,
 
@@ -72,6 +72,8 @@ export const GameLayout: React.FC = () => {
         
         <GameArea
           task={task}
+          taskObjective={taskObjective}
+          lastTaskResult={lastTaskResult}
           event={event}
           history={history}
           artifactsData={artifactsData}


### PR DESCRIPTION
## Summary
- add task goal definitions with objectives and rewards
- check task success each day and award coins, gems and badges
- display task goal and last reward in main game area

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad4f23f1c48324a83b24573ba156fc