### PR TITLE
refactor: use helpers for random game events

### DIFF
--- a/src/utils/game-logic.ts
+++ b/src/utils/game-logic.ts
@@ -158,10 +158,10 @@ export function generateRandomEvent(events: MarketEvent[]): MarketEvent | null {
 /**
  * Generate random dilemma question
  */
-export function generateRandomDilemma(
-	questions: string[],
-	askedQuestions: number[]
-): string | null {
+export function generateRandomDilemma<T>(
+        questions: T[],
+        askedQuestions: number[]
+): T | null {
 	if (Math.random() > GAME_CONFIG.DILEMMA_PROBABILITY) {
 		return null;
 	}


### PR DESCRIPTION
## Summary
- use centralized helpers for random events, dilemmas, quizzes, and Easter eggs
- handle days without events and clean up probability constants
- generalize `generateRandomDilemma` utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad53248c188324a88cad4e29291a81