### PR TITLE
feat: centralize task goals configuration

### DIFF
--- a/src/constants/task-goals.ts
+++ b/src/constants/task-goals.ts
@@ -1,0 +1,36 @@
+// Task objectives and rewards definitions
+
+export interface TaskGoal {
+  objective: string;
+  check: (weights: { [key: string]: number }) => boolean;
+  reward: { coins: number; gems: number; badge?: string };
+}
+
+export const taskGoals: Record<number, TaskGoal> = {
+  1: {
+    objective: '保持多元化：任何单一资产不超过50%',
+    check: (w) => Math.max(...Object.values(w)) <= 50,
+    reward: { coins: 20, gems: 1, badge: '分散者' },
+  },
+  2: {
+    objective: 'ESG 配置至少20%',
+    check: (w) => (w.esg || 0) >= 20,
+    reward: { coins: 20, gems: 1, badge: '绿色先锋' },
+  },
+  3: {
+    objective: '黄金配置至少20%',
+    check: (w) => (w.gold || 0) >= 20,
+    reward: { coins: 20, gems: 1, badge: '避险守护者' },
+  },
+  4: {
+    objective: '稳定币配置至少20%',
+    check: (w) => (w.stablecoin || 0) >= 20,
+    reward: { coins: 20, gems: 1, badge: '平静守护者' },
+  },
+  5: {
+    objective: '收益资产配置至少20%',
+    check: (w) => (w.yield || 0) >= 20,
+    reward: { coins: 20, gems: 1, badge: '收益智者' },
+  },
+};
+

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -9,6 +9,7 @@ import { handleSpinWheel as spinWheel } from '../modules/spinWheel';
 import aiPersonalities from '../constants/ai-personalities.json';
 import { assets as assetsData } from '../modules/assets';
 import { getAiResponse } from '../utils/ai';
+import { taskGoals } from '../constants/task-goals';
 import {
   calculateDailyReturns,
   generateRandomEvent,
@@ -19,41 +20,6 @@ import {
   checkGameEnd,
 } from '../utils/game-logic';
 import { GAME_CONFIG } from '../constants/game-config';
-
-// Task objectives and rewards
-const taskGoals: {
-  [id: number]: {
-    objective: string;
-    check: (w: { [key: string]: number }) => boolean;
-    reward: { coins: number; gems: number; badge?: string };
-  };
-} = {
-  1: {
-    objective: '保持多元化：任何单一资产不超过50%',
-    check: (w) => Math.max(...Object.values(w)) <= 50,
-    reward: { coins: 20, gems: 1, badge: '分散者' },
-  },
-  2: {
-    objective: 'ESG 配置至少20%',
-    check: (w) => (w.esg || 0) >= 20,
-    reward: { coins: 20, gems: 1, badge: '绿色先锋' },
-  },
-  3: {
-    objective: '黄金配置至少20%',
-    check: (w) => (w.gold || 0) >= 20,
-    reward: { coins: 20, gems: 1, badge: '避险守护者' },
-  },
-  4: {
-    objective: '稳定币配置至少20%',
-    check: (w) => (w.stablecoin || 0) >= 20,
-    reward: { coins: 20, gems: 1, badge: '平静守护者' },
-  },
-  5: {
-    objective: '收益资产配置至少20%',
-    check: (w) => (w.yield || 0) >= 20,
-    reward: { coins: 20, gems: 1, badge: '收益智者' },
-  },
-};
 
 export const useGameState = () => {
   // Company/Avatar Customization


### PR DESCRIPTION
## Summary
- extract task goals and reward checks into `src/constants/task-goals.ts`
- consume shared task goals in `useGameState`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad57d2953483249b5ee5e49a8d7131