### PR TITLE
feat: add easter egg message constant

### DIFF
--- a/src/constants/game-config.ts
+++ b/src/constants/game-config.ts
@@ -130,8 +130,16 @@ export const GAME_LEVELS = {
 
 // Level Experience Requirements
 export const LEVEL_EXPERIENCE = {
-	NOVICE: 0,
-	SKILLED: 100,
-	EXPERT: 500,
-	MASTER: 1000,
+        NOVICE: 0,
+        SKILLED: 100,
+        EXPERT: 500,
+        MASTER: 1000,
+} as const;
+
+// Game messages (prepared for localization)
+export const EASTER_EGG_MESSAGE =
+        '🎉 彩蛋事件：你发现了一只会跳舞的柴犬！\n\n奖励：收益+5%，心情+100！';
+
+export const GAME_MESSAGES = {
+        EASTER_EGG_MESSAGE,
 } as const;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -19,7 +19,7 @@ import {
   checkBadgeEligibility,
   checkGameEnd,
 } from '../utils/game-logic';
-import { GAME_CONFIG } from '../constants/game-config';
+import { GAME_CONFIG, EASTER_EGG_MESSAGE } from '../constants/game-config';
 import { INITIAL_STATE } from '../constants/initial-state';
 
 export const useGameState = () => {
@@ -278,7 +278,7 @@ export const useGameState = () => {
     // Fun event: meme or surprise
     if (checkEasterEgg()) {
       setShowModal(true);
-      setModalContent('🎉 彩蛋事件：你发现了一只会跳舞的柴犬！\n\n奖励：收益+5%，心情+100！');
+      setModalContent(EASTER_EGG_MESSAGE);
       setReturns(r => (r !== null ? r + 5 : 5));
       setCoins(c => c + 10);
       setGems(g => g + 1);


### PR DESCRIPTION
## Summary
- externalize Easter egg modal text into a constant and message map
- use EASTER_EGG_MESSAGE constant in nextDay function for easier localization

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d056308832499034a7e936ae7a1