### PR TITLE
refactor: use resource reward utility

### DIFF
--- a/src/utils/daily-helpers.ts
+++ b/src/utils/daily-helpers.ts
@@ -1,7 +1,11 @@
 // Daily flow helper functions
 
 import type { Asset, MarketEvent, Task, GameHistory } from '../types';
-import { calculateDailyReturns, checkBadgeEligibility } from './game-logic';
+import {
+  calculateDailyReturns,
+  checkBadgeEligibility,
+  calculateResourceRewards,
+} from './game-logic';
 import type { TaskGoal } from '../constants/task-goals';
 import { EASTER_EGG_MESSAGE } from '../constants/game-config';
 import { checkEasterEgg, generateRandomDilemma, generateRandomQuiz } from './game-logic';
@@ -55,8 +59,7 @@ export function applyDailyRewards({
   eventId,
   effect,
 }: ApplyDailyRewardsParams) {
-  const coins = Math.max(0, Math.floor(dayReturn / 10));
-  const gems = dayReturn > 50 ? 1 : 0;
+  const { coins, gems } = calculateResourceRewards(dayReturn);
   const stars = dayReturn > 0 ? 1 : 0;
 
   const goal = taskGoals[task.id];


### PR DESCRIPTION
## Summary
- use `calculateResourceRewards` for daily coin and gem calculation
- merge task rewards with resource rewards in daily helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad63a25b6c8324b5b5cda073732e6c