### PR TITLE
refactor: centralize weight sanitization

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -14,6 +14,7 @@ import {
   calculateDailyReturns,
   generateRandomEvent,
   checkGameEnd,
+  sanitizeWeights,
 } from '../utils/game-logic';
 import { GAME_CONFIG } from '../constants/game-config';
 import {
@@ -206,9 +207,7 @@ export const useGameState = () => {
 
   // Handle weight change
   const handleWeightChange = useCallback((key: string, value: number) => {
-    const sanitized = Object.fromEntries(
-      Object.entries(weights).map(([k, v]) => [k, allowedAssets.includes(k) ? v : 0])
-    ) as { [key: string]: number };
+    const sanitized = sanitizeWeights(weights, allowedAssets);
 
     if (!allowedAssets.includes(key)) {
       setWeights(sanitized);

--- a/src/utils/daily-helpers.ts
+++ b/src/utils/daily-helpers.ts
@@ -5,6 +5,7 @@ import {
   calculateDailyReturns,
   checkBadgeEligibility,
   calculateResourceRewards,
+  sanitizeWeights,
 } from './game-logic';
 import type { TaskGoal } from '../constants/task-goals';
 import { EASTER_EGG_MESSAGE } from '../constants/game-config';
@@ -78,9 +79,7 @@ export function applyDailyRewards({
     newBadges.push(goal.reward.badge);
   }
 
-  const sanitizedWeights = Object.fromEntries(
-    Object.entries(weights).map(([k, v]) => [k, allowedAssets.includes(k) ? v : 0])
-  );
+  const sanitizedWeights = sanitizeWeights(weights, allowedAssets);
 
   const historyEntry = {
     day: day + 1,

--- a/src/utils/game-logic.ts
+++ b/src/utils/game-logic.ts
@@ -15,6 +15,19 @@ const CORRELATIONS: { [key: string]: { [key: string]: number } } = {
 };
 
 /**
+ * Sanitize a weight map so that only allowed assets retain their values.
+ * Disallowed assets are set to 0.
+ */
+export function sanitizeWeights(
+        weights: Record<string, number>,
+        allowed: string[]
+): Record<string, number> {
+        return Object.fromEntries(
+                Object.entries(weights).map(([k, v]) => [k, allowed.includes(k) ? v : 0])
+        ) as Record<string, number>;
+}
+
+/**
  * Calculate daily portfolio metrics including return, volatility and drawdown
  */
 export function calculateDailyReturns(


### PR DESCRIPTION
## Summary
- add `sanitizeWeights` helper for consistent asset filtering
- refactor `handleWeightChange` and `applyDailyRewards` to use new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6503d11c8324baffa540010af644