### PR TITLE
Align coin rewards with daily returns

### DIFF
--- a/src/constants/game-config.ts
+++ b/src/constants/game-config.ts
@@ -23,7 +23,7 @@ export const GAME_CONFIG = {
 	
 	// Returns and Rewards
 	BASE_DAILY_RETURN: 0.02, // 2% base return
-	COIN_REWARD_RATIO: 0.1, // 10% of returns as coins
+        COIN_REWARD_RATIO: 1, // 1 coin per percentage point of returns
 	GEM_REWARD_THRESHOLD: 50, // 50% return threshold for gem reward
 	
 	// Badge Requirements

--- a/src/utils/__tests__/daily-helpers.test.ts
+++ b/src/utils/__tests__/daily-helpers.test.ts
@@ -47,7 +47,7 @@ describe('applyDailyRewards', () => {
       eventId: 123,
       effect: 'effect',
     });
-    expect(result.coins).toBe(26);
+    expect(result.coins).toBe(80);
     expect(result.gems).toBe(2);
     expect(result.stars).toBe(1);
     expect(result.newBadges).toContain('分散者');

--- a/src/utils/game-logic.ts
+++ b/src/utils/game-logic.ts
@@ -137,10 +137,10 @@ export function checkBadgeEligibility(
  * Calculate resource rewards based on returns
  */
 export function calculateResourceRewards(returns: number): { coins: number; gems: number } {
-	const coins = Math.max(0, Math.floor(returns * GAME_CONFIG.COIN_REWARD_RATIO));
-	const gems = returns > GAME_CONFIG.GEM_REWARD_THRESHOLD ? 1 : 0;
-	
-	return { coins, gems };
+        const coins = Math.max(0, Math.round(returns * GAME_CONFIG.COIN_REWARD_RATIO));
+        const gems = returns > GAME_CONFIG.GEM_REWARD_THRESHOLD ? 1 : 0;
+
+        return { coins, gems };
 }
 
 /**


### PR DESCRIPTION
## Summary
- align coin reward ratio so players earn one coin per percentage point of daily returns
- round coin rewards to track displayed returns more closely
- update tests for new reward logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad7e0740bc83248c176a4318c39293