### PR TITLE
fix: hide disabled assets from game area

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -76,7 +76,7 @@ export const GameLayout: React.FC = () => {
           lastTaskResult={lastTaskResult}
           event={event}
           history={history}
-          artifactsData={artifactsData}
+          artifactsData={artifactsData.filter(a => allowedAssets.includes(a.key))}
           weights={weights}
           returns={returns}
           volatility={volatility}


### PR DESCRIPTION
## Summary
- filter assets in `GameArea` so only parent-approved categories are shown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad817a0a5c8324b7eb58916eeedfe3