### PR TITLE
Filter market events by allowed assets

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -310,8 +310,8 @@ export const useGameState = () => {
       setTimeout(() => setShowSummary(true), 2500);
     }
 
-    // Pick a random event
-    const ev = generateRandomEvent(eventsData);
+    // Pick a random event based on allowed assets
+    const ev = generateRandomEvent(eventsData, allowedAssets);
     setEvent(ev);
 
     // If event has choices, wait for user decision

--- a/src/utils/__tests__/game-logic.test.ts
+++ b/src/utils/__tests__/game-logic.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateRandomEvent } from '../game-logic';
+import type { MarketEvent } from '../../types';
+
+describe('generateRandomEvent', () => {
+  it('filters out events for disallowed assets', () => {
+    const events: MarketEvent[] = [
+      {
+        id: 1,
+        name: 'Tech event',
+        description: '',
+        affected: ['tech'],
+        impactRange: { tech: [0, 0] },
+        probability: 1,
+      },
+      {
+        id: 2,
+        name: 'Crypto event',
+        description: '',
+        affected: ['crypto'],
+        impactRange: { crypto: [0, 0] },
+        probability: 1,
+      },
+    ];
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const ev = generateRandomEvent(events, ['tech']);
+    expect(ev?.id).toBe(1);
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when all events are disallowed', () => {
+    const events: MarketEvent[] = [
+      {
+        id: 1,
+        name: 'Crypto only',
+        description: '',
+        affected: ['crypto'],
+        impactRange: { crypto: [0, 0] },
+        probability: 1,
+      },
+    ];
+    const ev = generateRandomEvent(events, []);
+    expect(ev).toBeNull();
+  });
+});

--- a/src/utils/game-logic.ts
+++ b/src/utils/game-logic.ts
@@ -182,10 +182,20 @@ export function maybeSelectRandom<T>(
 }
 
 /**
- * Generate random market event
+ * Generate random market event filtered by allowed assets.
+ * Events that reference any disallowed asset are excluded.
  */
-export function generateRandomEvent(events: MarketEvent[]): MarketEvent | null {
-        return maybeSelectRandom(events, GAME_CONFIG.DAILY_EVENT_PROBABILITY);
+export function generateRandomEvent(
+        events: MarketEvent[],
+        allowedAssets: string[]
+): MarketEvent | null {
+        const eligible = events.filter(ev =>
+                ev.affected.every(asset => allowedAssets.includes(asset))
+        );
+        if (eligible.length === 0) {
+                return null;
+        }
+        return maybeSelectRandom(eligible, GAME_CONFIG.DAILY_EVENT_PROBABILITY);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Exclude market events tied to hidden assets when generating daily events
- Hook game state event picker into allowed asset list
- Add tests ensuring events for disallowed assets are skipped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8459b4208324b143dc719ad7c233